### PR TITLE
European Spanish - tweaks

### DIFF
--- a/datafiles/lang_mobile/European Spanish.ini
+++ b/datafiles/lang_mobile/European Spanish.ini
@@ -12,13 +12,13 @@ LoadGameContinue=@s¿CONTINUAR ESTA PARTIDA GUARDADA?@w
 
 [ControlOptions]
 GamepadOn=MANDO
-GamepadStyle=ESTILO DEL MANDO
+GamepadStyle=ESTILO DE MANDO
 AimAssist=ASIST. APUNTADO
 AutoAim=APUNTADO AUTO.
 # Allows swapping and using abilities by pressing volume buttons
 VolumeControls=TECLAS DE VOLUMEN
 # Split aim & fire into two separate control elements
-SplitFireControls=SEPARAR APUNTAR Y DISPARAR
+SplitFireControls=APUNTAR Y DISPARAR
 # Force player aim crosshair to be always visible
 FixedSight=MIRILLA FIJA
 TouchControlScale=ESCALA DE TAMAÑO
@@ -52,7 +52,7 @@ GambleToggle=BLOQ. APUESTA
 # Electric Guitar isn't translated in the basegame as of right now
 128:Name=GUITARRA ELÉCTRICA
 # Electric Guitar also uses the same description as the regular Guitar. NTM simply just adds a little sprinkle of detail to it
-128:Text=los peces pueden rocanrolear
+128:Text=fish puede rocanrolear
 
 [R:Stats]
 # Important! Stat entries should be as short as possible.
@@ -103,14 +103,14 @@ ExperimentalOptions=AJUSTES EXPERIMENTALES
 ProfileOptions=PERFIL
 
 [VideoOptions]
-WideScreen=PANTALLA PANORÁMICA
+WideScreen=PANT. PANORÁMICA
 Bloom=BLOOM
 Particles=PARTÍCULAS
 DisplayOptions=AJUSTES DE PANTALLA
 
 [Bosses]
 # "GUN GOD's" name isn't translated in the base game as of right now
-GunGod="DIOS#PISTOLA"
+GunGod="GUN#GOD"
 
 [ExperimentalOptions]
 KeyboardMode=MODO TECLADO


### PR DESCRIPTION
- Tweaked GamepadStyle and 128:Text to fit with the Nuclear Throne 10th Spanish anniversary localization
- Shortened SplitFireControls and Widescreen to fit on-screen
- Rolled back GunGod; Boss names aren't localized in the Spanish anniversary localization