### PR TITLE
European Spanish - updates and tweaks

### DIFF
--- a/datafiles/lang_mobile/European Spanish.ini
+++ b/datafiles/lang_mobile/European Spanish.ini
@@ -1,53 +1,53 @@
 # Last updated on 8 January 2026 at 05:16 GMT+3
 
 [ResourcepackBrowser]
-LoadingList=THE LIST IS LOADING...
-InstallationSuccess="@g%#INSTALLED SUCCESSFULLY!##CLICK ANYHWHERE TO CONTINUE"
-Installing=INSTALLING %
-InformationQuerying=QUERYING REPO INFO
+LoadingList=LA LISTA ESTÁ CARGANDO...
+InstallationSuccess="@g%#¡INSTALADO!##CLIC PARA CONTINUAR"
+Installing=INSTALANDO %
+InformationQuerying=SOLICITANDO INFO. DEL REPOSITORIO
 # Max. 8 characters
-ListRatingLabel=RATING
+ListRatingLabel=CALIFIC.
 # Max. 8 characters
-ListUpdateLabel=UPDATED
+ListUpdateLabel=ACTUALZ.
 # Installed resourcepack load order setting
-LoadPriority=LOAD PRIORITY
-SortMode=SORT
+LoadPriority=PRIORIDAD
+SortMode=ORDEN
 # Max. 8 characters
-SortByUpdate=UPDATED
+SortByUpdate=ACTUALZ.
 # Max. 8 characters
-SortByRating=RATING
-NoPacksInstalled=NO RESOURCEPACKS ARE CURRENTLY INSTALLED.
-PackDisabled=DISABLED
+SortByRating=CALIFIC.
+NoPacksInstalled=NO HAY PACKS DE RECURSOS INSTALADOS
+PackDisabled=DESACTIVADO
 # Should be as short as possible
-UpdatedLongAgo="LONG#AGO"
-NewPackPromotion=NEW!
-UpdatedJustNow=JUST NOW
-UpdatedToday=TODAY
-UpdatedYesterday=YESTERDAY
-UpdatedRecently=RECENTLY
-UpdatedThisWeek="THIS#WEEK"
-ErrorMissingFiles=MISSING RESOURCEPACK FILES
-FullviewOpenGitHub=SEE GITHUB PAGE
-ViewNoScreenshots=@dNO SCREENSHOTS :(
-FullviewPackInfo=PACK INFO
-FullviewCreationInfo=CREATED ON:
-FullviewLastUpdate=LAST UPDATED:
-FullviewInstallationDate=INSTALLED ON:
-FullviewStars=STARS:
-ButtonDownload=DOWNLOAD
-ButtonDisable=DISABLE
-ButtonEnable=ENABLE
+UpdatedLongAgo="HACE#MUCHO"
+NewPackPromotion=NUEVO!
+UpdatedJustNow=AHORA
+UpdatedToday=HOY
+UpdatedYesterday=AYER
+UpdatedRecently=RECIENT.
+UpdatedThisWeek="ESTA#SEM."
+ErrorMissingFiles=ARCHIVOS AUSENTES EN EL PACK
+FullviewOpenGitHub=VER PÁG. GITHUB
+ViewNoScreenshots=@dSIN CAPTURAS :(
+FullviewPackInfo=INFO. PACK
+FullviewCreationInfo=CREADO EN:
+FullviewLastUpdate=ÚLTIMA ACTUALZ.:
+FullviewInstallationDate=INSTALADO EN:
+FullviewStars=ESTRELLAS:
+ButtonDownload=DESCARGAR
+ButtonDisable=DESACTIVAR
+ButtonEnable=ACTIVAR
 
 
 [ControlOptions]
 GamepadOn=MANDO
-GamepadStyle=ESTILO DEL MANDO
+GamepadStyle=ESTILO DE MANDO
 AimAssist=ASIST. APUNTADO
 AutoAim=APUNTADO AUTO.
 # Allows swapping and using abilities by pressing volume buttons
 VolumeControls=TECLAS DE VOLUMEN
 # Split aim & fire into two separate control elements
-SplitFireControls=SEPARAR APUNTAR Y DISPARAR
+SplitFireControls=APUNTAR Y DISPARAR
 # Force player aim crosshair to be always visible
 FixedSight=MIRILLA FIJA
 TouchControlScale=ESCALA DE TAMAÑO
@@ -77,11 +77,11 @@ LoadGameNo=NO
 LoadGameContinue=@s¿CONTINUAR ESTA PARTIDA GUARDADA?@w
 
 [ResourcepackOptions]
-DisclaimerText="RESOURCEPACKS ARE AN EXCLUSIVE FEATURE OF#NUCLEAR THRONE MOBILE.##A RESOURCEPACK IS A USER-CREATED ASSET COLLECTION (TEXTURES, SOUNDS, TEXT) FOR DECORATIVE PURPOSES ONLY, WITH NO GAMEPLAY BENEFITS.##RESOURCEPACK BROWSER, DESPITE BING MODERATED,#MAY STILL CONTAIN QUESTIONABLE CONTENT.##THE DEVELOPER IS NOT LIABLE FOR ANY HARMFUL MATERIAL."
+DisclaimerText="LOS PACKS DE RECURSOS SON UNA CARACTERÍSTICA EXCLUSIVA DE#NUCLEAR THRONE MOBILE.##UN PACK DE RECURSOS ES UNA COLECCIÓN DE CONTENIDO HECHA POR EL USUARIO (TEXTURAS, SONIDOS, TEXTO) SOLO CON FINES DECORATIVOS, SIN BENEFICIOS DURANTE EL JUEGO.##EL NAVEGADOR DE PACKS DE RECURSOS, A PESAR DE RECIBIR MODERACIÓN,#PODRÍA CONTENER CONTENIDO CUESTIONABLE.##EL DESARROLLADOR NO ES RESPONSABLE DE NINGÚN CONTENIDO DAÑINO."
 # Delay before the user is able to proceed to resourcepack options
-DisclaimerProceedWait=@sPROCEED (%)
-DisclaimerProceed=@yPROCEED
-ResourcepackOptions=RESOURCEPACKS
+DisclaimerProceedWait=@sENTENDIDO (%)
+DisclaimerProceed=@yENTENDIDO
+ResourcepackOptions=PACKS DE RECURSOS
 ViewInstalled=VER INSTALADOS
 Browse=BUSCAR Y DESCARGAR
 DirectDownload=DESCARGA DIRECTA
@@ -101,7 +101,7 @@ GambleToggle=BLOQ. APUESTA
 # Electric Guitar isn't translated in the basegame as of right now
 128:Name=GUITARRA ELÉCTRICA
 # Electric Guitar also uses the same description as the regular Guitar. NTM simply just adds a little sprinkle of detail to it
-128:Text=los peces pueden rocanrolear
+128:Text=fish puede rocanrolear
 
 [ProfileOptions]
 ColorHEX=EDITAR HEX
@@ -120,12 +120,12 @@ DataOptions=DATOS
 [R:MainMenu]
 AchievementHidden=OCULTO
 Achievements=LOGROS
-DiscordLink=JOIN OUR DISCORD!
-RunHistory:daily=DAILY
-RunHistory:weekly=WEEKLY
-RunHistoryScoreAVG=@dAVERAGE SCORE
+DiscordLink=¡ÚNETE A NUESTRO DISCORD!
+RunHistory:daily=DIARIA
+RunHistory:weekly=SEMANAL
+RunHistoryScoreAVG=@dPUNT. PROMEDIO
 Leaderboards=TABLAS DE CLASIF.
-RunHistory=RUN HISTORY
+RunHistory=HIST. DE PARTIDAS
 
 [R:Stats]
 # Important! Stat entries should be as short as possible.
@@ -163,7 +163,7 @@ ExperimentalOptions=AJUSTES EXPERIMENTALES
 ProfileOptions=PERFIL
 
 [VideoOptions]
-WideScreen=PANTALLA PANORÁMICA
+WideScreen=PANT. PANORÁMICA
 Bloom=BLOOM
 Particles=PARTÍCULAS
 DisplayOptions=AJUSTES DE PANTALLA
@@ -175,7 +175,7 @@ HideJoysticks=OCULTAR JOYSTICKS
 
 [Bosses]
 # "GUN GOD's" name isn't translated in the base game as of right now
-GunGod="DIOS#PISTOLA"
+GunGod="GUN#GOD"
 
 [R:CoopLobby]
 Host=JUGAR COMO ANFITRIÓN
@@ -190,7 +190,7 @@ ProgressReset=BORRAR PROGRESO
 ContinuedRun=¡bienvenido de vuelta!
 
 [AudioOptions]
-SoundsVolume=EFFECTS VOLUME
+SoundsVolume=VOLUMEN DE LOS EFECTOS
 
 [R:HUD]
 PickUpAction=RECOGER


### PR DESCRIPTION
- Localized all new keys
- Tweaked GamepadStyle and 128:Text to fit with the Nuclear Throne 10th anniv. Spanish localization
- Shortened SplitFireControls and Widescreen to fit on-screen
- Rolled back GunGod; Boss names are kept in English in the Spanish anniv. localization